### PR TITLE
Added support for the AJAZZ AKP153 variant sold as the MiraBox HSV293S

### DIFF
--- a/40-streamdeck.rules
+++ b/40-streamdeck.rules
@@ -9,6 +9,7 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0086", MODE="0660", 
 SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE="0660", GROUP="plugdev"
@@ -22,6 +23,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0060", MODE="0660", GROUP="plugdev"
@@ -35,6 +37,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0fd9", ATTR{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="5548", ATTR{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="5548", ATTR{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTR{idVendor}=="0300", ATTR{idProduct}=="1010", MODE="0660", GROUP="plugdev"
 
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE="0660", GROUP="plugdev"
@@ -48,4 +51,5 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="009a", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6674", MODE="0660", GROUP="plugdev"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="5548", ATTRS{idProduct}=="6670", MODE="0660", GROUP="plugdev"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0300", ATTRS{idProduct}=="1010", MODE="0660", GROUP="plugdev"

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ But as it stands, this library should support following devices:
 - Stream Deck Neo (thanks to [@ejiektpobehuk](https://github.com/ejiektpobehuk), [@AkechiShiro](https://github.com/AkechiShiro) and [node-elgato-stream-deck](https://github.com/Julusian/node-elgato-stream-deck))
 - Ajazz AKP153 (thanks to [@ZCube](https://github.com/ZCube))
 - Ajazz AKP153E (thanks to [@teras](https://github.com/teras))
+- MiraBox HSV293S (thanks to [@czyz](https://github.com/czyz))

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -113,7 +113,7 @@ impl AsyncStreamDeck {
         Ok(block_in_place(move || device.write_image(key, image_data))?)
     }
 
-    /// Writes image data to Stream Deck device's lcd strip/screen as region. 
+    /// Writes image data to Stream Deck device's lcd strip/screen as region.
     /// Only Stream Deck Plus supports writing LCD regions, for Stream Deck Neo use write_lcd_fill
     pub async fn write_lcd(&self, x: u16, y: u16, rect: &ImageRect) -> Result<(), StreamDeckError> {
         let device = self.device.lock().await;
@@ -216,7 +216,7 @@ impl AsyncDeviceStateReader {
             StreamDeckInput::ButtonStateChange(buttons) => {
                 for (index, (their, mine)) in zip(buttons.iter(), my_states.buttons.iter()).enumerate() {
                     match self.device.kind {
-                        Kind::Akp153 | Kind::Akp153E => {
+                        Kind::Akp153 | Kind::Akp153E | Kind::MiraBoxHSV293S => {
                             if *their {
                                 updates.push(DeviceStateUpdate::ButtonDown(index as u8));
                                 updates.push(DeviceStateUpdate::ButtonUp(index as u8));

--- a/src/info.rs
+++ b/src/info.rs
@@ -28,6 +28,9 @@ pub const AJAZZ_VENDOR_ID_1: u16 = 0x5548;
 /// Product ID of Ajazz Stream Deck AKP153
 pub const PID_AJAZZ_AKP153: u16 = 0x6674;
 
+/// Product ID of the "FHOOU" (front label) and "MiraBox HSV293S" (rear label). Seems just like an AKP153.
+pub const PID_MIRABOX_HSV293S: u16 = 0x6670;
+
 /// Vendor ID of Ajazz Stream Deck AKP153E
 pub const AJAZZ_VENDOR_ID_2: u16 = 0x0300;
 
@@ -73,6 +76,8 @@ pub enum Kind {
     Akp153,
     /// Ajazz Stream Deck AKP153E
     Akp153E,
+    /// MiraBox HSV293S
+    MiraBoxHSV293S,
 }
 
 impl Kind {
@@ -92,13 +97,14 @@ impl Kind {
                 PID_STREAMDECK_PLUS => Some(Kind::Plus),
                 _ => None
             },
-            
+
             AJAZZ_VENDOR_ID_1 | AJAZZ_VENDOR_ID_2 => match pid {
                 PID_AJAZZ_AKP153 => Some(Kind::Akp153),
                 PID_AJAZZ_E_AKP153E => Some(Kind::Akp153E),
+                PID_MIRABOX_HSV293S => Some(Kind::MiraBoxHSV293S),
                 _ => None
-            }
-            
+            },
+
             _ => None
         }
     }
@@ -118,6 +124,7 @@ impl Kind {
             Kind::Plus => PID_STREAMDECK_PLUS,
             Kind::Akp153 => PID_AJAZZ_AKP153,
             Kind::Akp153E => PID_AJAZZ_E_AKP153E,
+            Kind::MiraBoxHSV293S => PID_MIRABOX_HSV293S,
         }
     }
 
@@ -136,6 +143,7 @@ impl Kind {
             Kind::Plus => ELGATO_VENDOR_ID,
             Kind::Akp153 => AJAZZ_VENDOR_ID_1,
             Kind::Akp153E => AJAZZ_VENDOR_ID_2,
+            Kind::MiraBoxHSV293S => AJAZZ_VENDOR_ID_1,
         }
     }
 
@@ -147,7 +155,7 @@ impl Kind {
             Kind::Xl | Kind::XlV2 => 32,
             Kind::Pedal => 3,
             Kind::Neo | Kind::Plus => 8,
-            Kind::Akp153 | Kind::Akp153E => 15 + 3,
+            Kind::Akp153 | Kind::Akp153E | Kind::MiraBoxHSV293S => 15 + 3,
         }
     }
 
@@ -160,6 +168,7 @@ impl Kind {
             Kind::Pedal => 1,
             Kind::Neo | Kind::Plus => 2,
             Kind::Akp153 | Kind::Akp153E => 3,
+            Kind::MiraBoxHSV293S => 3,
         }
     }
 
@@ -171,8 +180,7 @@ impl Kind {
             Kind::Xl | Kind::XlV2 => 8,
             Kind::Pedal => 3,
             Kind::Neo | Kind::Plus => 4,
-            Kind::Akp153 => 6,
-            Kind::Akp153E => 6,
+            Kind::Akp153 | Kind::Akp153E | Kind::MiraBoxHSV293S => 6,
         }
     }
 
@@ -197,7 +205,7 @@ impl Kind {
         match self {
             Kind::Plus => Some((800, 100)),
             Kind::Neo => Some((248, 58)),
-            Kind::Akp153 | Kind::Akp153E => Some((854, 480)), // logo
+            Kind::Akp153 | Kind::Akp153E | Kind::MiraBoxHSV293S => Some((854, 480)), // logo
             _ => None,
         }
     }
@@ -255,15 +263,16 @@ impl Kind {
 
             Kind::Pedal => ImageFormat::default(),
 
-            Kind::Akp153 | Kind::Akp153E => ImageFormat {
+            Kind::Akp153 | Kind::Akp153E | Kind::MiraBoxHSV293S => ImageFormat {
                 mode: ImageMode::JPEG,
                 size: (85, 85),
                 rotation: ImageRotation::Rot90,
                 mirror: ImageMirroring::Both,
             },
+
         }
     }
-    
+
     /// Image format used by LCD screen, used for filling LCD
     pub fn lcd_image_format(&self) -> Option<ImageFormat> {
         match self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,7 +114,7 @@ pub fn read_button_states(kind: &Kind, states: &Vec<u8>) -> Vec<bool> {
     }
 
     match kind {
-        Kind::Akp153 | Kind::Akp153E => {
+        Kind::Akp153 | Kind::Akp153E | Kind::MiraBoxHSV293S => {
             let mut bools = vec![];
 
             for i in 0..kind.key_count() {


### PR DESCRIPTION
Added support for the MiraBox HSV293S, which seems to be a variant of the AKP153 with "FHOOU" emblazoned on the front.